### PR TITLE
Update import paths to openvex/go-vex 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/google/go-containerregistry v0.12.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20220709202702-fa494aaa0add
-	github.com/openvex/vex v0.1.1-0.20230117021350-78649647b8fb
+	github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd
 	github.com/owenrumney/go-sarif v1.1.1
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
 	github.com/sigstore/cosign v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -1037,8 +1037,8 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/openvex/vex v0.1.1-0.20230117021350-78649647b8fb h1:R0OZhJcNmtIVTRJJfSPcqsWkpOi0A60WMrnX+iNt5gg=
-github.com/openvex/vex v0.1.1-0.20230117021350-78649647b8fb/go.mod h1:hyBd9x0no4IVW7VFP+wyVvqwX5mw7Lv5AhlN3owLhdY=
+github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd h1:ah2q0K3DchGUh7vDvnF4Dd+QHv/hNLXwiGALR3DrYfs=
+github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd/go.mod h1:jYmYbhQAO/0hquryXND/jMVDBcob8/KkVgzUEUAHsFI=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/vex"
 )
 
 type createOptions struct {

--- a/internal/cmd/filter.go
+++ b/internal/cmd/filter.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openvex/vex/pkg/sarif"
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/sarif"
+	"github.com/openvex/go-vex/pkg/vex"
 
 	"github.com/openvex/vexctl/pkg/ctl"
 )

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/vex"
 
 	"github.com/openvex/vexctl/pkg/ctl"
 )
@@ -26,7 +26,7 @@ func addMerge(parentCmd *cobra.Command) {
 	mergeCmd := &cobra.Command{
 		Short: fmt.Sprintf("%s merge: merges two or more VEX documents into one", appname),
 		Long: fmt.Sprintf(`%s merge: merge one or more documents into one
-
+	
 When composing VEX data out of multiple sources it may be necessary to mix
 all statements into a single doc. The merge subcommand mixes the statements
 from one or more vex documents into a single, new one.

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	ovattest "github.com/openvex/vex/pkg/attestation"
+	ovattest "github.com/openvex/go-vex/pkg/attestation"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"

--- a/pkg/ctl/ctl.go
+++ b/pkg/ctl/ctl.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openvex/vex/pkg/sarif"
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/sarif"
+	"github.com/openvex/go-vex/pkg/vex"
 
 	"github.com/openvex/vexctl/pkg/attestation"
 )

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/openvex/vex/pkg/sarif"
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/sarif"
+	"github.com/openvex/go-vex/pkg/vex"
 )
 
 func TestVexReport(t *testing.T) {

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -30,8 +30,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-utils/util"
 
-	"github.com/openvex/vex/pkg/sarif"
-	"github.com/openvex/vex/pkg/vex"
+	"github.com/openvex/go-vex/pkg/sarif"
+	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/openvex/vexctl/pkg/attestation"
 )
 


### PR DESCRIPTION
This PR updates all import paths after the main vex repository was renamed to go-vex

/cc @luhring 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>