### PR TITLE
Build vexctl image and provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,42 +6,89 @@ name: Release
 on:
   push:
     tags:
-    - 'v*'
+      - 'v*'
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
-      contents: write
+      contents: write # needed to write releases
+      id-token: write # needed for keyless signing
+      packages: write # needed for pushing the images to ghcr.io
 
     env:
       GO111MODULE: on
       COSIGN_EXPERIMENTAL: "true"
 
     steps:
-    - name: Check out code onto GOPATH
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.0.2
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.0.2
 
-    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.3.0
-      with:
-        go-version: 1.19
-        check-latest: true
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.3.0
+        with:
+          go-version: 1.19
+          check-latest: true
 
-    - name: Install cosign
-      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2
+      - name: Install cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
 
-    - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@8f67e590f2d095516493f017008adc464e63adb1 # v3.1.0
-      with:
-        install-only: true
+      - name: Get TAG
+        id: get_tag
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-    - name: Get TAG
-      id: get_tag
-      run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Set LDFLAGS
+        id: ldflags
+        run: |
+            source ./release/ldflags.sh
+            goflags=$(ldflags)
+            echo "GO_FLAGS="${goflags}"" >> "$GITHUB_ENV"
 
-    - name: Run goreleaser
-      run: make release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        id: run-goreleaser
+        uses: goreleaser/goreleaser-action@8f67e590f2d095516493f017008adc464e63adb1 # v4.1.0
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LDFLAGS: ${{ env.GO_FLAGS }}
+
+      - name: Generate subject
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [release]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: false # do not upload to a new release since goreleaser creates it
+
+  release-provenance:
+    needs: [provenance]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # To read the workflow path.
+      contents: write # To add assets to a release.
+    steps:
+      - name: Download the provenance
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{needs.provenance.outputs.provenance-name}}
+
+      - name: Release Provenance
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        id: release-provenance
+        with:
+          draft: true
+          files: ${{needs.provenance.outputs.provenance-name}}

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ rootfs.tar
 vexctl
 dist/**
 .go-version
+/vexImagerefs

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ before:
   hooks:
     - go mod tidy
     - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+    - /bin/bash -c 'make build-sign-release-images'
 
 gomod:
   proxy: true
@@ -62,9 +63,9 @@ signs:
     artifacts: checksum
 
 archives:
-- format: binary
-  name_template: "{{ .Binary }}"
-  allow_different_binary_count: true
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 defaultBaseImage: cgr.dev/chainguard/static:latest
 

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,18 @@
+---
+defaultBaseImage: cgr.dev/chainguard/static:latest
+
+builds:
+  - id: vexctl
+    dir: .
+    main: .
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - --tags
+      - "{{ .Env.GIT_HASH }}"
+      - --tags
+      - "{{ .Env.GIT_VERSION }}"
+    ldflags:
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION)
         -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
         -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
         -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
+
+
+KO_PREFIX ?= ghcr.io/openvex
+export KO_DOCKER_REPO=$(KO_PREFIX)
+
 ## Build
 .PHONY: vex
 vex: # build the binaries
@@ -46,3 +51,16 @@ release:
 .PHONY: snapshot
 snapshot:
 	LDFLAGS="$(LDFLAGS)" goreleaser release --rm-dist --snapshot --skip-sign --skip-publish --timeout 120m
+
+.PHONY: ko
+ko:
+	# vexctl
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	KO_DOCKER_REPO=$(KO_PREFIX)/vexctl ko build --bare \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--image-refs vexImagerefs github.com/openvex/vexctl
+
+.PHONY: build-sign-release-images
+build-sign-release-images: ko
+	GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	./release/ko-sign-release-images.sh

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ ko:
 .PHONY: build-sign-release-images
 build-sign-release-images: ko
 	GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	./release/ko-sign-release-images.sh
+	./scripts/ko-sign-release-images.sh

--- a/scripts/ko-sign-release-images.sh
+++ b/scripts/ko-sign-release-images.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${GIT_HASH:?Environment variable empty or not defined.}"
+: "${GIT_VERSION:?Environment variable empty or not defined.}"
+
+if [[ ! -f vexImagerefs ]]; then
+    echo "vexImagerefs not found"
+    exit 1
+fi
+
+echo "Signing images with Keyless..."
+cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat vexImagerefs)

--- a/scripts/ldflags.sh
+++ b/scripts/ldflags.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Output LDFlAGS for a given environment. LDFLAGS are applied to all go binary
+# builds.
+#
+# Args: env
+function ldflags() {
+  local GIT_VERSION=$(git describe --tags --always --dirty)
+  local GIT_COMMIT=$(git rev-parse HEAD)
+
+  local GIT_TREESTATE="clean"
+  if [[ $(git diff --stat) != '' ]]; then
+    GIT_TREESTATE="dirty"
+  fi
+
+  local DATE_FMT="+%Y-%m-%dT%H:%M:%SZ"
+  local BUILD_DATE=$(date "$DATE_FMT")
+  local SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+  if [ $SOURCE_DATE_EPOCH ]
+  then
+      local BUILD_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT")
+  fi
+
+  echo "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$GIT_VERSION \
+        -X sigs.k8s.io/release-utils/version.gitCommit=$GIT_COMMIT \
+        -X sigs.k8s.io/release-utils/version.gitTreeState=$GIT_TREESTATE \
+        -X sigs.k8s.io/release-utils/version.buildDate=$BUILD_DATE"
+}


### PR DESCRIPTION
- build `vexctl` image using ko
- refactor the release job to generate the provenance

