### PR TITLE
Use vex.Open instead of vex.Load to support CSAF

### DIFF
--- a/csaf.json
+++ b/csaf.json
@@ -1,0 +1,100 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Example VEX document.",
+        "title": "Document Title"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "Example Company",
+      "namespace": "https://psirt.example.com"
+    },
+    "title": "Example VEX Document",
+    "tracking": {
+      "current_release_date": "2022-03-03T11:00:00.000Z",
+      "generator": {
+        "date": "2022-03-03T11:00:00.000Z",
+        "engine": {
+          "name": "Secvisogram",
+          "version": "1.11.0"
+        }
+      },
+      "id": "2022-EVD-UC-01-NA-001",
+      "initial_release_date": "2022-03-03T11:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2022-03-03T11:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "product": {
+              "name": "Example Company ABC 4.2",
+              "product_id": "CSAFPID-0001",
+              "product_identification_helper": {
+                "purl": "pkg:maven/@1.3.4"
+              }
+            },                
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "4.2",
+                "product": {
+                  "name": "Example Company ABC 4.2",
+                  "product_id": "INTERNAL-0001",
+                  "product_identification_helper": {
+                    "purl": "pkg:golang/github.com/go-homedir@v1.1.0"
+                  }
+                }
+              }
+            ],
+            "category": "product_name",
+            "name": "ABC"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2009-4487",
+      "notes": [
+        {
+          "category": "description",
+          "text": "nginx 0.7.64 writes data to a log file without sanitizing non-printable characters, which might allow remote attackers to modify a window's title, or possibly execute arbitrary commands or overwrite files, via an HTTP request containing an escape sequence for a terminal emulator.",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-0001"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Class with vulnerable code was removed before shipping.",
+          "product_ids": [
+            "CSAFPID-0001"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/csaf/README.md
+++ b/examples/csaf/README.md
@@ -1,0 +1,81 @@
+# CSAF Examples
+
+This directory is intended to contain CSAF files to test the OpenVEX tooling
+capabilities to read CSAF VEX. On the long run, as the feature matures, we
+should write some tests to ensure we are ingesting CSAF properly.
+
+## Ingesting CSAF Documents
+
+`vexctl` should be able to detect and read VEX statements in CSAF documents.
+The easiest way to test is to invoke it to `vexctl merge` just one CSAF document,
+this should return an OpenVEX document created from the data in the CSAF file:
+
+```bash
+vexctl merge examples/csaf/csaf.json 
+```
+
+### Output:
+
+```json
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "merged-vex-23b3bef63c834f02772204d8c823c5c7d35db12b31518b3b111752b3f991769a",
+  "author": "Unknown Author",
+  "role": "Document Creator",
+  "timestamp": "2023-06-09T12:01:32.239990099-06:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": "CVE-2009-4487",
+      "timestamp": "2022-03-03T11:00:00.000Z",
+      "products": [
+        "pkg:generic/component1@1.3.4"
+      ],
+      "status": "not_affected",
+      "action_statement": "Class with vulnerable code was removed before shipping."
+    }
+  ]
+}
+```
+
+`vexctl merge` can also can read VEX data from documents in different formats
+and compose a single document with statements coming from all documents. Using
+the example files we can create a new document from our example CSAF file and
+a sample OpenVEX document:
+
+```bash
+vexctl merge examples/csaf/csaf.json examples/csaf/openvex.json
+```
+
+### Output:
+
+```json
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "merged-vex-d036fc7d69d1dddc641ab6f19e604be821fef5c9b2db00e0ed6bffe5ab9c470e",
+  "author": "Unknown Author",
+  "role": "Document Creator",
+  "timestamp": "2023-06-19T17:27:53.725858678-06:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": "CVE-2009-4487",
+      "timestamp": "2022-03-03T11:00:00.000Z",
+      "products": [
+        "pkg:generic/component1@1.3.4"
+      ],
+      "status": "not_affected",
+      "action_statement": "Class with vulnerable code was removed before shipping."
+    },
+    {
+      "vulnerability": "CVE-2014-123456",
+      "timestamp": "2023-01-08T18:02:03.647Z",
+      "products": [
+        "pkg:generic/component2@2.39.0-r1"
+      ],
+      "status": "fixed"
+    }
+  ]
+}
+
+```

--- a/examples/csaf/csaf.json
+++ b/examples/csaf/csaf.json
@@ -1,0 +1,87 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Example VEX document.",
+        "title": "Document Title"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "Example Company",
+      "namespace": "https://psirt.example.com"
+    },
+    "title": "Example VEX Document",
+    "tracking": {
+      "current_release_date": "2022-03-03T11:00:00.000Z",
+      "generator": {
+        "date": "2022-03-03T11:00:00.000Z",
+        "engine": {
+          "name": "Secvisogram",
+          "version": "1.11.0"
+        }
+      },
+      "id": "2022-EVD-UC-01-NA-001",
+      "initial_release_date": "2022-03-03T11:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2022-03-03T11:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "product": {
+              "name": "Example Company ABC 4.2",
+              "product_id": "CSAFPID-0001",
+              "product_identification_helper": {
+                "purl": "pkg:generic/component1@1.3.4"
+              }
+            },
+            "category": "product_name",
+            "name": "ABC"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2009-4487",
+      "notes": [
+        {
+          "category": "description",
+          "text": "nginx 0.7.64 writes data to a log file without sanitizing non-printable characters, which might allow remote attackers to modify a window's title, or possibly execute arbitrary commands or overwrite files, via an HTTP request containing an escape sequence for a terminal emulator.",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-0001"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Class with vulnerable code was removed before shipping.",
+          "product_ids": [
+            "CSAFPID-0001"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/csaf/openvex.json
+++ b/examples/csaf/openvex.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "https://openvex.dev/docs/example/vex-9fb3463de1b57",
+  "author": "Wolfi J Inkinson",
+  "role": "Document Creator",
+  "timestamp": "2023-01-08T18:02:03.647787998-06:00",
+  "version": "1",
+  "statements": [
+    {
+      "vulnerability": "CVE-2014-123456",
+      "products": [
+        "pkg:generic/component2@2.39.0-r1"
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/examples/csaf/sbom.spdx.json
+++ b/examples/csaf/sbom.spdx.json
@@ -1,0 +1,95 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "SBOM-SPDX-15d23b0e-1397-45bf-b356-c26fa409feb6",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-03-01T07:03:32Z",
+    "creators": [
+      "Person: Adolfo García Veytia (puerco@chainguard.dev)"
+    ]
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/puerco/tests/a62a0654-0646-49da-9fcb-6c6b8766657f",
+  "documentDescribes": [
+    "SPDXRef-Package-image"
+  ],
+  "files": [],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-image",
+      "name": "image",
+      "versionInfo": "v1.0.0",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "CONTAINER",
+      "licenseConcluded": "Apache-2.0",
+      "downloadLocation": "NONE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "603a6c7216a53d02889d4da068703478dc570644f9f76b1a99f6683775f9abeb"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:oci/image@sh256%3A2603a6c7216a53d02889d4da068703478dc570644f9f76b1a99f6683775f9abeb",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-component1",
+      "name": "component1",
+      "versionInfo": "1.3.4",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "LIBRARY",
+      "licenseConcluded": "Apache-2.0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e32cf64960f27d402cf0ef1c15fcef97425da8c1ac238ff868125c5e2df64f2f"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:generic/component1@1.3.4",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-component2",
+      "name": "component2",
+      "versionInfo": "2.39.0-r1",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "LIBRARY",
+      "licenseDeclared": "Apache-2.0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4d59fac9a8aa85ca7fdd1d4ae629e2408b3f2903f0a2e148f56d902bb5d480b1"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:generic/component2@2.39.0-r1",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-image",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-component1"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-image",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-component2"
+    }
+  ]
+}

--- a/examples/openvex/README.md
+++ b/examples/openvex/README.md
@@ -1,0 +1,4 @@
+# Sample OpenVEX Files
+
+This directory holds a few example OpenVEX files which can be used to test the
+tools (`vexctl merge`, `vexctl attest` etc). 

--- a/examples/openvex/demo.vex.json
+++ b/examples/openvex/demo.vex.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "https://openvex.dev/docs/example/vex-9fb3463de1b57",
+  "author": "Wolfi J Inkinson",
+  "role": "Document Creator",
+  "timestamp": "2023-01-08T18:02:03.647787998-06:00",
+  "version": "1",
+  "statements": [
+    {
+      "vulnerability": "CVE-2014-123456",
+      "products": [
+        "pkg:apk/distro/git@2.39.0-r1?arch=armv7",
+        "pkg:apk/distro/git@2.39.0-r1?arch=x86_64"
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/examples/openvex/document1.vex.json
+++ b/examples/openvex/document1.vex.json
@@ -1,0 +1,16 @@
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "https://openvex.dev/docs/public/vex-3f59b4dffdeae0183e5e6a9d7a2461fdf86a03c079f4129050bb462eca366beb",
+  "author": "John Doe",
+  "role": "Senior Trusted VEX Issuer",
+  "statements": [
+    {
+      "timestamp": "2022-12-22T16:36:43-05:00",
+      "products": [
+        "pkg:apk/wolfi/bash@1.0.0"
+      ],
+      "vulnerability": "CVE-1234-5678",
+      "status": "under_investigation"
+    }
+  ]
+}

--- a/examples/openvex/document2.vex.json
+++ b/examples/openvex/document2.vex.json
@@ -1,0 +1,16 @@
+{
+  "@context": "https://openvex.dev/ns",
+  "@id": "https://openvex.dev/docs/public/vex-cb43f7eeb498d81f73148766a030a0060de2331c367c12d203592ea84650a31c",
+  "author": "John Doe",
+  "role": "Senior Trusted VEX Issuer",
+  "statements": [
+    {
+      "timestamp": "2022-12-22T20:56:05-05:00",
+      "products": [
+        "pkg:apk/wolfi/bash@1.0.0"
+      ],
+      "vulnerability": "CVE-1234-5678",
+      "status": "fixed"
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/in-toto/in-toto-golang v0.9.0
-	github.com/openvex/go-vex v0.2.0
+	github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9
 	github.com/owenrumney/go-sarif v1.1.1
 	github.com/secure-systems-lab/go-securesystemslib v0.6.0
 	github.com/sigstore/cosign/v2 v2.0.3-0.20230511235414-95ae338878ae

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openvex/go-vex v0.2.0 h1:7Q6VzdpZSZzYUyXB1dio/9LCGHp1iL3JldC+hMsbFg0=
 github.com/openvex/go-vex v0.2.0/go.mod h1:jYmYbhQAO/0hquryXND/jMVDBcob8/KkVgzUEUAHsFI=
+github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9 h1:ilWy/S/hyHiZnf6AMRYY0ND8vX7c3PzShTKN/1caKmo=
+github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9/go.mod h1:0pEm6soF5H/q5ef3looeeq6AcNb9bvKuxCBEjxcHqFY=
 github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -386,12 +386,13 @@ func (impl *defaultVexCtlImplementation) LoadFiles(
 ) ([]*vex.VEX, error) {
 	vexes := make([]*vex.VEX, len(filePaths))
 	for i, path := range filePaths {
-		doc, err := vex.Load(path)
+		doc, err := vex.Open(path)
 		if err != nil {
 			return nil, fmt.Errorf("error loading file: %w", err)
 		}
 		vexes[i] = doc
 	}
+
 	return vexes, nil
 }
 


### PR DESCRIPTION
This commit modifies vexctl to use the new `vex.Open()` call instead of `vex.Load()`. This lets it automatically load CSAF documents in its subcommands.

It also adds a bunch of examples to test.


~~Hold merging, it needs [go-vex#25](https://github.com/openvex/go-vex/pull/25) and a rebase~~