### PR TITLE
Fix --subcomponents flag

### DIFF
--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -221,7 +221,7 @@ Examples:
 	)
 
 	createCmd.PersistentFlags().StringSliceVar(
-		&opts.Products,
+		&opts.Subcomponents,
 		"subcomponents",
 		[]string{},
 		"list of subcomponents to add to the statement",


### PR DESCRIPTION
This PR fixes a bug where the subcomponents flag in the create subcommand was overwriting the product field.

Fixes #88

Thanks @chipzoller for reporting!

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>