### PR TITLE
bump to openvex/go-vex@v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/in-toto/in-toto-golang v0.9.0
-	github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9
+	github.com/openvex/go-vex v0.2.1
 	github.com/owenrumney/go-sarif v1.1.1
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0
 	github.com/sigstore/cosign/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9 h1:ilWy/S/hyHiZnf6AMRYY0ND8vX7c3PzShTKN/1caKmo=
-github.com/openvex/go-vex v0.2.1-0.20230531025847-386386bf8ab9/go.mod h1:0pEm6soF5H/q5ef3looeeq6AcNb9bvKuxCBEjxcHqFY=
+github.com/openvex/go-vex v0.2.1 h1:OiZlTwYnT7jQjv68JRk+CmEcz+YAQhNQkJxg6kSkvuc=
+github.com/openvex/go-vex v0.2.1/go.mod h1:BkkoLLIZxS5D8yDKM9pe6eRDHF00H2PuqNBnOxaExz0=
 github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=


### PR DESCRIPTION
This commit bumps the go-vex libraries to v0.2.1. It reimplements the `vex.StatementFromID()` deprecated function as it was breaking the vexctl tests.

Supersedes https://github.com/openvex/vexctl/pull/94

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>