### PR TITLE
revamp release job, cleanups and add snapshot job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
       COSIGN_YES: "true"
 
     outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
       tag_name: ${{ steps.tag.outputs.tag_name }}
 
     steps:
@@ -37,9 +36,10 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # v3.2.0
 
+      - name: Install bom
+        uses: puerco/release-actions/setup-bom@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
+
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-        with:
-          version: v0.14.1
 
       - name: Get TAG
         id: get_tag
@@ -56,7 +56,6 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | ko login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Run GoReleaser
-        id: run-goreleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
@@ -65,31 +64,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LDFLAGS: ${{ env.GO_FLAGS }}
 
-      - name: Generate subject
-        id: hash
-        env:
-          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
-        run: |
-          set -euo pipefail
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
-
       - name: build images
         run: make build-sign-release-images || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  provenance:
+  attestation:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
     needs:
       - release
 
-    permissions:
-      actions: read # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
+    steps:
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 1
 
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
-    with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true # upload to a new release
-      upload-tag-name: "${{ needs.release.outputs.tag_name }}"
+      - name: Set tag output
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Install tejolote
+        uses: puerco/release-actions/setup-tejolote@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
+
+      - run: |
+          tejolote attest --artifacts github://openvex/vexctl/${{ steps.tag.outputs.tag_name }} github://openvex/vexctl/"${GITHUB_RUN_ID}" --output vexctl.intoto.json --sign
+
+      - name: Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          files: vexctl.intoto.json
+          tag_name: "${{ steps.tag.outputs.tag_name }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_REPOSITORY: openvex/vexctl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,7 @@ jobs:
       packages: write # needed for pushing the images to ghcr.io
 
     env:
-      GO111MODULE: on
       COSIGN_YES: "true"
-
-    outputs:
-      tag_name: ${{ steps.tag.outputs.tag_name }}
 
     steps:
       - name: Check out code onto GOPATH
@@ -41,19 +37,12 @@ jobs:
 
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
 
-      - name: Get TAG
-        id: get_tag
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
       - name: Set LDFLAGS
         id: ldflags
         run: |
             source ./release/ldflags.sh
             goflags=$(ldflags)
             echo "GO_FLAGS="${goflags}"" >> "$GITHUB_ENV"
-
-      - name: Log into ghcr.io
-        run: echo ${{ secrets.GITHUB_TOKEN }} | ko login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
@@ -63,6 +52,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LDFLAGS: ${{ env.GO_FLAGS }}
+
+      - name: Log into ghcr.io
+        run: echo ${{ secrets.GITHUB_TOKEN }} | ko login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: build images
         run: make build-sign-release-images || true

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,0 +1,35 @@
+name: Snapshot
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.21'
+          check-latest: true
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          install-only: true
+
+      - name: Install bom
+        uses: puerco/release-actions/setup-bom@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
+
+      - name: Run Snapshot
+        run: make snapshot
+
+      - name: check binary
+        run: |
+          ./dist/vexctl-linux-amd64 version

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Snapshot
 
 on:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54
+          version: v1.55
           args: --timeout=5m

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
 project_name: vexctl
 
 env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-project_name: vex
+project_name: vexctl
 
 env:
   - GO111MODULE=on
@@ -47,24 +47,34 @@ builds:
       - CGO_ENABLED=0
 
 signs:
-  # Keyless
-  - id: binary-keyless
+  - id: vexctl-keyless
     signature: "${artifact}.sig"
     certificate: "${artifact}.pem"
     cmd: cosign
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
-    artifacts: binary
-  - id: checksum-keyless
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
-    cmd: cosign
-    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
-    artifacts: checksum
+    artifacts: all
 
 archives:
   - format: binary
     name_template: "{{ .Binary }}"
     allow_different_binary_count: true
+
+sboms:
+  - id: vexctl
+    cmd: bom
+    args:
+      - generate
+      - "--output"
+      - "vexctl-bom.json.spdx"
+      - "-d"
+      - "../"
+      - "-c"
+      - "../.vexctl-bom-config.yaml"
+      - "--format"
+      - "json"
+    artifacts: any
+    documents:
+      - "vexctl-bom.json.spdx"
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
@@ -74,3 +84,6 @@ snapshot:
 
 release:
   prerelease: auto
+
+changelog:
+  use: github-native

--- a/.vexctl-bom-config.yaml
+++ b/.vexctl-bom-config.yaml
@@ -1,0 +1,48 @@
+---
+namespace: https://openvex/vexctl
+license: Apache-2.0
+name: vexctl
+creator:
+ person: The OpenVEX Authors
+ tool: vexctl
+
+artifacts:
+  - type: file
+    source: vexctl-windows-amd64.exe
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-darwin-amd64
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-darwin-arm64
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-linux-amd64
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-linux-arm
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-linux-arm64
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-linux-ppc64le
+    license: Apache-2.0
+    gomodules: true
+
+  - type: file
+    source: vexctl-linux-s390x
+    license: Apache-2.0
+    gomodules: true

--- a/.vexctl-bom-config.yaml
+++ b/.vexctl-bom-config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 The OpenVEX Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 namespace: https://openvex/vexctl
 license: Apache-2.0

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release:
 
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --clean--snapshot --skip=sign,publish --timeout 120m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --clean --snapshot --skip=sign,publish --timeout 120m
 
 .PHONY: ko
 ko:

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ test:
 
 .PHONY: release
 release:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --rm-dist --timeout 120m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --clean --timeout 120m
 
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --rm-dist --snapshot --skip-sign --skip-publish --timeout 120m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --clean--snapshot --skip=sign,publish --timeout 120m
 
 .PHONY: ko
 ko:


### PR DESCRIPTION
- bump golangci-lint to v1.55.x
- add sboms and revamp the provanance with k8s-release actions tools
- cleanup
- add snapshot job


release rehearsal: https://github.com/cpanato/vexctl/releases/tag/v99.99.00 / https://github.com/cpanato/vexctl/actions/runs/6955168726