### PR TITLE
Add support for Golang GO-* vulnerability identifier

### DIFF
--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -122,7 +122,7 @@ func (impl *defaultVexCtlImplementation) ApplySingleVEX(report *sarif.Report, ve
 					newResults = append(newResults, res)
 					continue
 				}
-			case "GHSA", "PRISMA", "RHSA", "RUSTSEC", "SNYK":
+			case "GHSA", "GO", "PRISMA", "RHSA", "RUSTSEC", "SNYK":
 				id = strings.TrimSpace(*res.RuleID)
 			default:
 				newResults = append(newResults, res)


### PR DESCRIPTION
https://pkg.go.dev/vuln/GO-2022-0379 is an example of such an issue that doesn't have a corresponding CVE. At least Prisma Cloud reports this by its Golang identifier.