### PR TITLE
fix(create): support multiple `--product` flags

### DIFF
--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -102,10 +102,10 @@ to preserve the original file, specify it using the --file flag:
 					}
 					opts.documentPath = args[i]
 				case 1:
-					if opts.Product != "" && opts.Product != args[i] {
+					if len(opts.Products) != 1 && len(args) != 1 {
 						return errors.New("product can only be specified once")
 					}
-					opts.Product = args[i]
+					opts.Products = append(opts.Products, args[i])
 				case 2:
 					if opts.Vulnerability != "" && opts.Vulnerability != args[i] {
 						return errors.New("vulnerability can only be specified once")

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -87,10 +87,14 @@ Examples:
 			for i := range args {
 				switch i {
 				case 0:
-					if opts.Product != "" && opts.Product != args[i] {
-						return errors.New("product can only be specified once")
+					if len(opts.Products) > 0 && args[i] != "" {
+						return errors.New("multiple products can only be specified using the --product flag")
 					}
-					opts.Product = args[i]
+					// Specifying multiple products through args is not supported as we can't tell how many products are provided:
+					// e.g the second argument could be a vulnerability or a status instead of a product, for example.
+					// When using args only the first one is considered a product.
+					// To specify multiple products, use the --product flag multiple times instead.
+					opts.Products = append(opts.Products, args[i])
 				case 1:
 					if opts.Vulnerability != "" && opts.Vulnerability != args[i] {
 						return errors.New("vulnerability can only be specified once")

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -84,6 +84,10 @@ func (so *vexStatementOptions) Validate() error {
 		return errors.New("a minimum of one product id is needed to generate a valid VEX statement")
 	}
 
+	if len(so.Products) > 1 && len(so.Subcomponents) > 0 {
+		return errors.New("subcomponent(s) cannot be defined when specifying multiple products because it's unclear which subcomponent(s) belong to which products")
+	}
+
 	if so.Vulnerability == "" {
 		return errors.New("a vulnerability ID is required to generate a valid VEX statement")
 	}

--- a/internal/cmd/options_test.go
+++ b/internal/cmd/options_test.go
@@ -54,35 +54,35 @@ func TestVexStatementOptionsValidate(t *testing.T) {
 		},
 		"empty product": {
 			vexStatementOptions{
-				Status:  string(vex.StatusUnderInvestigation),
-				Product: "",
+				Status:   string(vex.StatusUnderInvestigation),
+				Products: []string{},
 			}, true,
 		},
 		"empty vulnerability": {
 			vexStatementOptions{
 				Status:        string(vex.StatusUnderInvestigation),
-				Product:       "pkg:golang/fmt",
+				Products:      []string{"pkg:golang/fmt"},
 				Vulnerability: "",
 			}, true,
 		},
 		"empty status": {
 			vexStatementOptions{
 				Status:        "",
-				Product:       "pkg:golang/fmt",
+				Products:      []string{"pkg:golang/fmt"},
 				Vulnerability: "CVE-2014-12345678",
 			}, true,
 		},
 		"invalid status": {
 			vexStatementOptions{
 				Status:        "cheese",
-				Product:       "pkg:golang/fmt",
+				Products:      []string{"pkg:golang/fmt"},
 				Vulnerability: "CVE-2014-12345678",
 			}, true,
 		},
 		"justification on non-not-affected": {
 			vexStatementOptions{
 				Status:        string(vex.StatusUnderInvestigation),
-				Product:       "pkg:golang/fmt",
+				Products:      []string{"pkg:golang/fmt"},
 				Vulnerability: "CVE-2014-12345678",
 				Justification: "justification goes here",
 			}, true,
@@ -90,7 +90,7 @@ func TestVexStatementOptionsValidate(t *testing.T) {
 		"impact statement on non-not-affected": {
 			vexStatementOptions{
 				Status:          string(vex.StatusUnderInvestigation),
-				Product:         "pkg:golang/fmt",
+				Products:        []string{"pkg:golang/fmt"},
 				Vulnerability:   "CVE-2014-12345678",
 				ImpactStatement: "buffer underrun is never run under",
 			}, true,
@@ -98,7 +98,7 @@ func TestVexStatementOptionsValidate(t *testing.T) {
 		"ok": {
 			vexStatementOptions{
 				Status:        string(vex.StatusUnderInvestigation),
-				Product:       "pkg:golang/fmt",
+				Products:      []string{"pkg:golang/fmt"},
 				Vulnerability: "CVE-2014-12345678",
 			}, false,
 		},
@@ -114,7 +114,7 @@ func TestAddOptionsValidate(t *testing.T) {
 	stubOpts := vexStatementOptions{
 		Status:        "fixed",
 		Vulnerability: "CVE-2014-1234678",
-		Product:       "pkg:generic/test@1.00",
+		Products:      []string{"pkg:generic/test@1.00"},
 	}
 
 	// create a test directory and a file in it

--- a/internal/cmd/options_test.go
+++ b/internal/cmd/options_test.go
@@ -95,6 +95,14 @@ func TestVexStatementOptionsValidate(t *testing.T) {
 				ImpactStatement: "buffer underrun is never run under",
 			}, true,
 		},
+		"can't associate a subcomponent when multiple products are defined": {
+			vexStatementOptions{
+				Status:        string(vex.StatusNotAffected),
+				Products:      []string{"pkg:oci/alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126", "pkg:oci/busybox@sha256:c6ab5a1a2bc330f3f9616b20c7fba7716cadd941514cf80f8d7c3da8af6b0946"},
+				Subcomponents: []string{"pkg:golang/fmt"},
+				Vulnerability: "CVE-2014-12345678",
+			}, true,
+		},
 		"ok": {
 			vexStatementOptions{
 				Status:        string(vex.StatusUnderInvestigation),


### PR DESCRIPTION
This PR adds supports for having multiple `--product` flags.

Fixes https://github.com/openvex/vexctl/issues/215.