### PR TITLE
Add support to vulnerability aliases

### DIFF
--- a/internal/cmd/options_test.go
+++ b/internal/cmd/options_test.go
@@ -103,6 +103,22 @@ func TestVexStatementOptionsValidate(t *testing.T) {
 				Vulnerability: "CVE-2014-12345678",
 			}, true,
 		},
+		"repeated aliases found": {
+			vexStatementOptions{
+				Status:        string(vex.StatusUnderInvestigation),
+				Products:      []string{"pkg:golang/fmt"},
+				Vulnerability: "CVE-2014-12345678",
+				Aliases:       []string{"CVE-2014-1234", "CVE-2014-1234"},
+			}, true,
+		},
+		"repeated alias and vulnerability ID": {
+			vexStatementOptions{
+				Status:        string(vex.StatusUnderInvestigation),
+				Products:      []string{"pkg:golang/fmt"},
+				Vulnerability: "CVE-2014-12345678",
+				Aliases:       []string{"CVE-2014-1234", "CVE-2014-12345678"},
+			}, true,
+		},
 		"ok": {
 			vexStatementOptions{
 				Status:        string(vex.StatusUnderInvestigation),


### PR DESCRIPTION
This is an initial implementation that adds support to vulnerability aliases as documented in the [spec](https://github.com/openvex/spec/blob/52dd5645b4a37e723a27e7ac22f7e0e4abb5deed/OPENVEX-SPEC.md?plain=1#L333).

Note that support is only added when creating a new Vex document or adding a new statement. It doesn't support filtering or merging based on aliases.

Closes https://github.com/openvex/vexctl/issues/219