### PR TITLE
Fix Copyright in Boilerplates

### DIFF
--- a/pkg/ctl/ctl.go
+++ b/pkg/ctl/ctl.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Chainguard, Inc.
+Copyright 2022 The OpenVEX Authors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Chainguard, Inc.
+Copyright 2022 The OpenVEX Authors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Chainguard, Inc.
+Copyright 2022 The OpenVEX Authors
 SPDX-License-Identifier: Apache-2.0
 */
 


### PR DESCRIPTION
This PR fixes a few copyright headers which we forgot to update after the donation of the project to @ossf and which are causing warning to be printed on CI runs.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
