### PR TITLE
Improve the generated template README

### DIFF
--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -47,21 +47,22 @@ const (
 		"`vexctl generate` when generating VEX data for a release or\n" +
 		"a specific artifact.\n\n" +
 		"To add new statements to publish data about a vulnerability,\n" +
-		"download [vexctl](https://github.com/openvex/vexctl)\n" +
-		"and append new statements using `vexctl add`. For example:\n\n" +
+		"download [vexctl] and append new statements using\n" +
+		"`vexctl add`. For example:\n\n" +
 		"```\n" +
-		"vexctl add --in-place main.openvex.json pkg:oci/test CVE-2014-1234567 fixed\n" +
+		"vexctl add --in-place main.openvex.json --product pkg:oci/test --vuln CVE-2014-1234567 --status under_investigation\n" +
 		"```\n\n" +
 		"That will add a new VEX statement expressing that the impact of\n" +
 		"CVE-2014-1234567 is under investigation in the test image. When\n" +
-		"cutting a new release, for `pkg:oci/test` the new file will be\n" +
-		"incorporated to the relase's VEX data.\n\n" +
+		"cutting a new release, for `pkg:oci/test` the new file can be\n" +
+		"incorporated to the release's VEX data.\n\n" +
 		"## Read more about OpenVEX\n\n" +
 		"To know more about generating, publishing and using VEX data\n" +
 		"in your project, please check out the [vexctl repository and\n" +
-		"documentation](https://github.com/openvex/vexctl).\n\n" +
-		"OpenVEX also has an [examples repository](https://github.com/openvex/examples)\n" +
-		"with samples and docs.\n"
+		"documentation][vexctl].\n\n" +
+		"OpenVEX also has an [examples repository] with samples and docs.\n\n\n" +
+		"[vexctl]: https://github.com/openvex/vexctl\n" +
+		"[examples repository]: https://github.com/openvex/examples\n"
 )
 
 type Implementation interface {


### PR DESCRIPTION
Small suggestion to improve the generated template README with:

1. Update the example command.
2. The status referenced `fixed`, but the text `under investigation`.
3. Some formatting improvements.
4. Typo fixes.

### Before

![image](https://github.com/openvex/vexctl/assets/17654553/5785aa65-1819-4549-b1e0-858e3c37a719)

### After

![image](https://github.com/openvex/vexctl/assets/17654553/f71e4ac2-ad76-4e3f-8cb4-015068f46d8b)