### PR TITLE
Reverse platform+os naming cheme

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,7 +59,7 @@ signs:
 archives:
   - formats:
       - binary
-    name_template: "{{ .ProjectName }}-{{ .Arch }}-{{ .Os }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     allow_different_binary_count: true
 
 sboms:


### PR DESCRIPTION
The artifact naming scheme was reversed in https://github.com/openvex/vexctl/commit/ed4170beb4943f84a6d460382ea4580ae7f4590d and the installer action is broken. This change should correct the names and restore the installer.