### PR TITLE
Do not dereference a missing document timestamp in ApplySingleVEX

### DIFF
--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gosarif "github.com/owenrumney/go-sarif/sarif"
@@ -100,7 +101,14 @@ func (impl *defaultVexCtlImplementation) ApplySingleVEX(report *sarif.Report, ve
 	logrus.Infof("VEX document contains %d statements", len(vexDoc.Statements))
 
 	sortedStatements := vexDoc.Statements
-	vex.SortStatements(sortedStatements, *vexDoc.Timestamp)
+	// The document timestamp is optional and only acts as a fallback for
+	// statements that carry none of their own, so a document without one must
+	// not be dereferenced.
+	docTimestamp := time.Time{}
+	if vexDoc.Timestamp != nil {
+		docTimestamp = *vexDoc.Timestamp
+	}
+	vex.SortStatements(sortedStatements, docTimestamp)
 
 	// Search for negative VEX statements, that is those that cancel a CVE
 	for i := range report.Runs {

--- a/pkg/ctl/implementation_test.go
+++ b/pkg/ctl/implementation_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	intoto "github.com/in-toto/attestation/go/v1"
+	gosarif "github.com/owenrumney/go-sarif/sarif"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openvex/go-vex/pkg/sarif"
 	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/openvex/vexctl/pkg/attestation"
 )
@@ -420,4 +422,33 @@ func TestInitTemplatesDir(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestApplySingleVEXNoDocumentTimestamp(t *testing.T) {
+	// The document timestamp is optional, and vex.Open returns a document
+	// without one, so ApplySingleVEX must not dereference it.
+	doc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"https://example.com/vex/1",` +
+		`"author":"test","version":1,"statements":[{"vulnerability":{"name":"CVE-2024-0001"},` +
+		`"products":[{"@id":"pkg:oci/test"}],"status":"not_affected",` +
+		`"justification":"component_not_present"}]}`
+
+	path := filepath.Join(t.TempDir(), "no-timestamp.vex.json")
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
+
+	vexDoc, err := vex.Open(path)
+	require.NoError(t, err)
+	require.Nil(t, vexDoc.Timestamp)
+
+	// A rule ID that is not a vulnerability identifier, so the result is kept
+	// as is and the assertion stays on the timestamp handling.
+	report := sarif.New()
+	run := gosarif.NewRun("test", "https://example.com")
+	ruleID := "gosec-G101"
+	run.Results = append(run.Results, &gosarif.Result{RuleID: &ruleID})
+	report.Runs = append(report.Runs, run)
+
+	impl := defaultVexCtlImplementation{}
+	newReport, err := impl.ApplySingleVEX(report, vexDoc)
+	require.NoError(t, err)
+	require.Len(t, newReport.Runs[0].Results, 1)
 }


### PR DESCRIPTION
`ApplySingleVEX` starts with:

```go
vex.SortStatements(sortedStatements, *vexDoc.Timestamp)
```

The document timestamp is optional in OpenVEX, and `vex.Open` returns a document with `Timestamp == nil` without complaint, so `vexctl filter report.sarif doc.vex.json` panics on a document that simply omits it, before any result is examined:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

The timestamp is only used as the fallback date for statements that carry none of their own, and `SortStatements` already handles the zero time, so this falls back to `time.Time{}` instead of dereferencing.

Related: the same pattern exists one level down in `go-vex`, at `StatementsByVulnerability`, which I have a PR open for at openvex/go-vex#227. The two are independent, this one panics first and is reachable even when no statement matches the report.

Test: `TestApplySingleVEXNoDocumentTimestamp` writes a valid document with no `timestamp`, opens it through `vex.Open`, and applies it to a small SARIF report. It panics on main and passes here. `go test ./...` is green.