### PR TITLE
fix: append package name to repository_url when normalizing oci purls

### DIFF
--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -552,6 +552,12 @@ func (impl *defaultVexCtlImplementation) NormalizeProducts(subjects []productRef
 			qs := p.Qualifiers.Map()
 			if r, ok := qs["repository_url"]; ok {
 				ref = strings.TrimSuffix(r, "/")
+				// The repository_url qualifier may or may not already
+				// include the package name (both forms are seen in the
+				// wild), so only append it if it's not there yet.
+				if ref != p.Name && !strings.HasSuffix(ref, "/"+p.Name) {
+					ref += "/" + p.Name
+				}
 			} else {
 				// digest or image
 				ref = p.Name

--- a/pkg/ctl/implementation_test.go
+++ b/pkg/ctl/implementation_test.go
@@ -61,6 +61,14 @@ func TestNormalizeProducts(t *testing.T) {
 			shouldFail:           false,
 		},
 		{
+			name:                 "purl, repository_url without package name",
+			products:             []productRef{{Name: "pkg:oci/ubuntu?repository_url=localhost:5000/demo&tag=24.04"}},
+			expectedImage:        []productRef{{Name: "localhost:5000/demo/ubuntu:24.04", Hashes: make(map[vex.Algorithm]vex.Hash)}},
+			expectedOther:        []productRef{},
+			expectedUnattestable: []productRef{},
+			shouldFail:           false,
+		},
+		{
 			name:                 "purl, dockerhub",
 			products:             []productRef{{Name: "pkg:oci/nginx"}},
 			expectedImage:        []productRef{{Name: "nginx", Hashes: make(map[vex.Algorithm]vex.Hash)}},


### PR DESCRIPTION
## Summary

Fixes a bug where `vexctl attest` fails with `subject <ref> has no digests` when an OCI purl's `repository_url` qualifier doesn't already include the package name (per the purl spec, it usually shouldn't).

`NormalizeProducts` used `repository_url` verbatim as the image reference, silently dropping the package name whenever it wasn't already baked into `repository_url`.

Example from the upstream bug report:

```
pkg:oci/ubuntu?repository_url=localhost:5000/demo&tag=24.04
```

was being converted to `localhost:5000/demo:24.04` instead of `localhost:5000/demo/ubuntu:24.04`, so the digest lookup targeted the wrong reference and attestation failed.

The fix only appends the package name when `repository_url` doesn't already end with it, so both purl shapes seen in the wild (with and without the name embedded in `repository_url`) keep working — including the existing `purl, custom registry` test case.

Upstream issue: openvex/vexctl#346

## Test plan

- Added a regression test case (`purl, repository_url without package name`) reproducing the exact purl from the issue report.
- `go test ./...` passes.
- `go vet ./...` and `go build ./...` clean.