### PR TITLE
Add OWNERS and aliases with new maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - vexctl-approvers
+reviewers:
+  - vexctl-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,14 @@
+aliases:
+    vexctl-approvers:
+        - cpanato # Core active maintainer
+        - lumjjb # Core active maintainer
+        - macedogm # Core active maintainer
+        - puerco # Core active maintainer
+    vexctl-reviewers:
+        - cpanato # Core active maintainer
+        - luhring # Core maintainer
+        - lumjjb # Core active maintainer
+        - macedogm # Core active maintainer
+        - puerco # Core active maintainer
+        - rnjudge # Core maintainer
+        - wagoodman # Core maintainer


### PR DESCRIPTION
This commit adds the OWNERS and OWNERS_ALIASES files with the new active maintainer roster.