### PR TITLE
fix(attestation): exchange the ephemeral key for a Fulcio certificate

### DIFF
--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -142,11 +142,24 @@ func signAttestation(ctx context.Context, ko *options.KeyOpts, att *Attestation)
 	// the args here and if we're reusing the bundle, set it in ko.BundlePath
 	// Note that in this call we hardocde the pats empty, but we should get them
 	// from somewhere.
-	sv, _, err := sign.SignerFromKeyOpts(ctx, "", "", *ko)
+	sv, genKey, err := sign.SignerFromKeyOpts(ctx, "", "", *ko)
 	if err != nil {
 		return fmt.Errorf("getting signer: %w", err)
 	}
 	defer sv.Close()
+
+	// SignerFromKeyOpts only generates a local ephemeral key on the default
+	// keyless path (no --sk, no --key); it does not itself talk to Fulcio.
+	// When genKey is true we still need to exchange that ephemeral key for a
+	// short-lived certificate via KeylessSigner, mirroring cosign's own
+	// cmd/cosign/cli/attest/attest.go. Skipping this step leaves sv.Cert nil,
+	// so the certificate later uploaded to Rekor is empty (vexctl#428).
+	if genKey {
+		sv, err = sign.KeylessSigner(ctx, *ko, sv)
+		if err != nil {
+			return fmt.Errorf("getting keyless signer: %w", err)
+		}
+	}
 
 	// Wrap the attestation in the DSSE envelope
 	wrapped := dsse.WrapSigner(sv, "application/vnd.in-toto+json")

--- a/pkg/attestation/attestation_signkeyless_repro_test.go
+++ b/pkg/attestation/attestation_signkeyless_repro_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The OpenVEX Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+)
+
+// TestSignAttestationKeylessFollowsUpWithKeylessSigner reproduces the failure
+// reported in issue #428 ("vexctl attest" / "Attestation signing is
+// broken"):
+//
+//	Error: generating attestation: signing attestation: recording signature
+//	data to transparency log: uploading to transparency log: public key
+//	provided has 0 length
+//
+// Root cause: signAttestation() called sign.SignerFromKeyOpts() but discarded
+// the returned "genKey" bool (`sv, _, err := sign.SignerFromKeyOpts(...)`)
+// and never followed up with sign.KeylessSigner(), which is the call that
+// actually talks to the OIDC issuer and Fulcio to populate
+// SignerVerifier.Cert. Compare with cosign's own
+// cmd/cosign/cli/attest/attest.go (same dependency version), which does:
+//
+//	sv, genKey, err := cosign_sign.SignerFromKeyOpts(...)
+//	if genKey || c.IssueCertificateForExistingKey {
+//	        sv, err = cosign_sign.KeylessSigner(ctx, c.KeyOpts, sv)
+//	}
+//
+// Because vexctl skipped that step, for the default keyless code path (no
+// --sk, no --key -- exactly what "vexctl attest" without extra flags uses)
+// SignerVerifier.Cert stayed nil, so att.SignatureData.CertData ended up
+// empty. appendSignatureDataToTLog() then hands this empty CertData to
+// cosign.TLogUploadDSSEEnvelope() as the certificate/public key, which Rekor
+// rejects with "public key provided has 0 length".
+//
+// Exercising the real KeylessSigner() success path needs a live interactive
+// OIDC device-code login against a Fulcio instance, which is not viable in
+// an automated test. Instead this test points KeyOpts.OIDCIssuer at an
+// address nothing listens on, so the OIDC token exchange that KeylessSigner
+// performs fails fast (connection refused) instead of blocking on user
+// interaction. That gives an observable, network-independent difference
+// between the buggy and the fixed code:
+//
+//   - Buggy code: signAttestation() never reaches sign.KeylessSigner(), so a
+//     bogus OIDCIssuer is never even contacted -- signAttestation() returns
+//     nil error and a signer with an empty (nil) certificate.
+//   - Fixed code: signAttestation() calls sign.KeylessSigner() whenever
+//     genKey is true, which tries to reach the (bogus) OIDC issuer and
+//     fails -- signAttestation() returns a non-nil error.
+func TestSignAttestationKeylessFollowsUpWithKeylessSigner(t *testing.T) {
+	att := New()
+
+	ko := options.KeyOpts{
+		FulcioURL: options.DefaultFulcioURL,
+		RekorURL:  options.DefaultRekorURL,
+		// Nothing listens on this address, so the OIDC token exchange that
+		// KeylessSigner performs fails immediately instead of falling back
+		// to an interactive device-code login.
+		OIDCIssuer:               "http://127.0.0.1:1",
+		OIDCClientID:             "sigstore",
+		InsecureSkipFulcioVerify: false,
+		SkipConfirmation:         true,
+	}
+
+	err := signAttestation(context.Background(), &ko, att)
+	if err == nil {
+		t.Fatalf("BUG REPRODUCED (vexctl#428): signAttestation() returned no " +
+			"error for a bogus OIDCIssuer on the default keyless signing " +
+			"path -- this means sign.KeylessSigner() was never called, so " +
+			"the resulting certificate is empty. appendSignatureDataToTLog() " +
+			"later uploads that empty certificate to Rekor, which fails " +
+			"with 'public key provided has 0 length'")
+	}
+}


### PR DESCRIPTION
Fixes #428.

`vexctl attest` failed at the transparency-log step with:

```
uploading to transparency log: public key provided has 0 length
```

`signAttestation` calls `sign.SignerFromKeyOpts` but drops its second return value (`genKey`) and never follows up with `sign.KeylessSigner`. On the default keyless path — no `--sk`, no `--key`, which is what plain `vexctl attest` uses — `SignerFromKeyOpts` only creates a local ephemeral key and does not talk to Fulcio, so `SignerVerifier.Cert` stays nil. The empty certificate then travels into `appendSignatureDataToTLog` → `cosign.TLogUploadDSSEEnvelope`, and Rekor rejects it with the message above.

cosign's own `cmd/cosign/cli/attest/attest.go` does the follow-up step:

```go
sv, genKey, err := cosign_sign.SignerFromKeyOpts(...)
if genKey || c.IssueCertificateForExistingKey {
        sv, err = cosign_sign.KeylessSigner(ctx, c.KeyOpts, sv)
}
```

This change mirrors it: keep `genKey`, and when it is set, exchange the ephemeral key for a short-lived Fulcio certificate. Signing with `--key`/`--sk` is unaffected, since `genKey` is false there.

**Test.** Exercising a successful keyless signature needs an interactive OIDC login against a live Fulcio, which is not viable in CI. The regression test instead points `KeyOpts.OIDCIssuer` at an address nothing listens on, which makes the two code paths observably different without depending on any external service:

* before the fix `KeylessSigner` is never reached, so the bogus issuer is never contacted and `signAttestation` returns **no error** — the test fails with the explanation of what that means;
* after the fix the OIDC exchange is attempted and fails fast, so `signAttestation` returns an error — the test passes.

`go test ./pkg/attestation/`, `go vet` and `gofmt` are clean.
